### PR TITLE
📝 Update snapshot options docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,7 @@ $ percy exec -- node script.js
 
 - `driver` (**required**) - A `selenium-webdriver` driver instance
 - `name` (**required**) - The snapshot name; must be unique to each snapshot
-- `options` - Additional snapshot options (overrides any project options)
-  - `options.widths` - An array of widths to take screenshots at
-  - `options.minHeight` - The minimum viewport height to take screenshots at
-  - `options.percyCSS` - Percy specific CSS only applied in Percy's rendering environment
-  - `options.requestHeaders` - Headers that should be used during asset discovery
-  - `options.enableJavaScript` - Enable JavaScript in Percy's rendering environment
+- `options` - [See per-snapshot configuration options](https://docs.percy.io/docs/cli-configuration#per-snapshot-configuration)
 
 ## Upgrading
 


### PR DESCRIPTION
## What is this?

With our snapshot options being standardized / the same across all SDKs, it'd be more future proof to link to a single snapshot options doc. 