### PR TITLE
Responsive snapshot capture + slow scrolling for CS

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ async function captureResponsiveDOM(driver, options) {
   /* istanbul ignore next: no instrumenting injected code */
   await driver.executeScript('PercyDOM.waitForResize()');
   let height = currentHeight;
-  if (process.env.RESPONSIVE_CAPTURE_USE_MIN_HEIGHT) {
+  if (process.env.PERCY_RESPONSIVE_CAPTURE_USE_MIN_HEIGHT) {
     height = await driver.executeScript(`return window.outerHeight - window.innerHeight + ${utils.percy?.config?.snapshot?.minHeight}`);
   }
   for (let width of widths) {
@@ -82,10 +82,10 @@ async function captureResponsiveDOM(driver, options) {
       await new Promise(resolve => setTimeout(resolve, parseInt(process.env.RESPONSIVE_CAPTURE_SLEEP_TIME) * 1000));
     }
 
-    if (process.env.RESPONSIVE_CAPTURE_SCROLL_ENABLED) {
+    if (process.env.PERCY_RESPONSIVE_CAPTURE_SCROLL_ENABLED) {
       let scrollSleep = 0.45;
-      if (process.env.RESPONSIVE_CAPTURE_SCROLL_TIME) {
-        scrollSleep = parseFloat(process.env.RESPONSIVE_CAPTURE_SCROLL_TIME);
+      if (process.env.PERCY_RESPONSIVE_CAPTURE_SCROLL_TIME) {
+        scrollSleep = parseFloat(process.env.PERCY_RESPONSIVE_CAPTURE_SCROLL_TIME);
       }
       await module.exports.slowScrollToBottom(driver, scrollSleep);
     }
@@ -284,8 +284,8 @@ module.exports.slowScrollToBottom = async (driver, timeInSeconds = 0.45) => {
   // Get back to top
   await driver.executeScript('window.scrollTo(0, 0)');
   let sleepAfterScroll = 1;
-  if (process.env.SLEEP_AFTER_SCROLL_DONE) {
-    sleepAfterScroll = parseFloat(process.env.SLEEP_AFTER_SCROLL_DONE);
+  if (process.env.PERCY_SLEEP_AFTER_SCROLL_DONE) {
+    sleepAfterScroll = parseFloat(process.env.PERCY_SLEEP_AFTER_SCROLL_DONE);
   }
   await new Promise(resolve => setTimeout(resolve, sleepAfterScroll * 1000));
 };

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const utils = require('@percy/sdk-utils');
 const { DriverMetadata } = require('./driverMetadata');
 const log = utils.logger('selenium-webdriver');
 const CS_MAX_SCREENSHOT_LIMIT = 25000;
+const SCROLL_DEFAULT_SLEEP_TIME = 0.45; // 450ms
 
 const getWidthsForMultiDOM = (userPassedWidths, eligibleWidths) => {
   // Deep copy of eligible mobile widths
@@ -69,7 +70,7 @@ async function captureResponsiveDOM(driver, options) {
   /* istanbul ignore next: no instrumenting injected code */
   await driver.executeScript('PercyDOM.waitForResize()');
   let height = currentHeight;
-  if (process.env.PERCY_RESPONSIVE_CAPTURE_USE_MIN_HEIGHT) {
+  if (process.env.PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT) {
     height = await driver.executeScript(`return window.outerHeight - window.innerHeight + ${utils.percy?.config?.snapshot?.minHeight}`);
   }
   for (let width of widths) {
@@ -84,7 +85,7 @@ async function captureResponsiveDOM(driver, options) {
     }
 
     if (process.env.PERCY_ENABLE_LAZY_LOADING_SCROLL) {
-      let scrollSleep = 0.45;
+      let scrollSleep = SCROLL_DEFAULT_SLEEP_TIME;
       if (process.env.PERCY_LAZY_LOAD_SCROLL_TIME) {
         scrollSleep = parseFloat(process.env.PERCY_LAZY_LOAD_SCROLL_TIME);
       }
@@ -266,7 +267,7 @@ module.exports.isPercyEnabled = async function isPercyEnabled() {
   return await utils.isPercyEnabled();
 };
 
-module.exports.slowScrollToBottom = async (driver, timeInSeconds = 0.45) => {
+module.exports.slowScrollToBottom = async (driver, timeInSeconds = SCROLL_DEFAULT_SLEEP_TIME) => {
   let scrollHeight = Math.min(await driver.executeScript('return document.documentElement.scrollHeight'), 25000);
   const clientHeight = await driver.executeScript('return document.documentElement.clientHeight');
   let current = 0;

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const getWidthsForMultiDOM = (userPassedWidths, eligibleWidths) => {
 async function changeWindowDimensionAndWait(driver, width, height, resizeCount) {
   try {
     const caps = await driver.getCapabilities();
-    if (typeof driver?.sendDevToolsCommand === 'function' && caps.getBrowserName() === 'chrome') {
+    if (typeof driver?.sendDevToolsCommand === 'function' && caps.getBrowserName() === 'chrome' && process.env.PERCY_DISABLE_CDP_RESIZE !== 'true') {
       await driver?.sendDevToolsCommand('Emulation.setDeviceMetricsOverride', {
         height,
         width,

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ module.exports.isPercyEnabled = async function isPercyEnabled() {
 };
 
 module.exports.slowScrollToBottom = async (driver, timeInSeconds = SCROLL_DEFAULT_SLEEP_TIME) => {
-  let scrollHeight = Math.min(await driver.executeScript('return document.documentElement.scrollHeight'), 25000);
+  let scrollHeight = Math.min(await driver.executeScript('return document.documentElement.scrollHeight'), CS_MAX_SCREENSHOT_LIMIT);
   const clientHeight = await driver.executeScript('return document.documentElement.clientHeight');
   let current = 0;
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const ENV_INFO = `${seleniumPkg.name}/${seleniumPkg.version}`;
 const utils = require('@percy/sdk-utils');
 const { DriverMetadata } = require('./driverMetadata');
 const log = utils.logger('selenium-webdriver');
+const CS_MAX_SCREENSHOT_LIMIT = 25000;
 
 const getWidthsForMultiDOM = (userPassedWidths, eligibleWidths) => {
   // Deep copy of eligible mobile widths
@@ -82,10 +83,10 @@ async function captureResponsiveDOM(driver, options) {
       await new Promise(resolve => setTimeout(resolve, parseInt(process.env.RESPONSIVE_CAPTURE_SLEEP_TIME) * 1000));
     }
 
-    if (process.env.PERCY_RESPONSIVE_CAPTURE_SCROLL_ENABLED) {
+    if (process.env.PERCY_ENABLE_LAZY_LOADING_SCROLL) {
       let scrollSleep = 0.45;
-      if (process.env.PERCY_RESPONSIVE_CAPTURE_SCROLL_TIME) {
-        scrollSleep = parseFloat(process.env.PERCY_RESPONSIVE_CAPTURE_SCROLL_TIME);
+      if (process.env.PERCY_LAZY_LOAD_SCROLL_TIME) {
+        scrollSleep = parseFloat(process.env.PERCY_LAZY_LOAD_SCROLL_TIME);
       }
       await module.exports.slowScrollToBottom(driver, scrollSleep);
     }
@@ -272,7 +273,7 @@ module.exports.slowScrollToBottom = async (driver, timeInSeconds = 0.45) => {
 
   let page = 1;
   // Break the loop if maximum scroll height 25000px is reached
-  while (scrollHeight > current && current < 25000) {
+  while (scrollHeight > current && current < CS_MAX_SCREENSHOT_LIMIT) {
     current = clientHeight * page;
     page += 1;
     await driver.executeScript(`window.scrollTo(0, ${current})`);
@@ -284,8 +285,8 @@ module.exports.slowScrollToBottom = async (driver, timeInSeconds = 0.45) => {
   // Get back to top
   await driver.executeScript('window.scrollTo(0, 0)');
   let sleepAfterScroll = 1;
-  if (process.env.PERCY_SLEEP_AFTER_SCROLL_DONE) {
-    sleepAfterScroll = parseFloat(process.env.PERCY_SLEEP_AFTER_SCROLL_DONE);
+  if (process.env.PERCY_SLEEP_AFTER_LAZY_LOAD_COMPLETE) {
+    sleepAfterScroll = parseFloat(process.env.PERCY_SLEEP_AFTER_LAZY_LOAD_COMPLETE);
   }
   await new Promise(resolve => setTimeout(resolve, sleepAfterScroll * 1000));
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/selenium-webdriver",
   "description": "Selenium client library for visual testing with Percy",
-  "version": "2.2.1-beta.0",
+  "version": "2.2.2-alpha.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-selenium-js",
@@ -12,7 +12,7 @@
   ],
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "alpha"
   },
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/selenium-webdriver",
   "description": "Selenium client library for visual testing with Percy",
-  "version": "2.2.2-alpha.0",
+  "version": "2.2.2-alpha.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-selenium-js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/selenium-webdriver",
   "description": "Selenium client library for visual testing with Percy",
-  "version": "2.2.2-alpha.1",
+  "version": "2.2.2-alpha.2",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-selenium-js",

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -217,9 +217,10 @@ describe('percySnapshot', () => {
 
     const mockedScroll = spyOn(percySnapshot, 'slowScrollToBottom').and.resolveTo(true);
 
+    mockedDriver.executeScript.calls.reset();
     await percySnapshot(mockedDriver, 'Test Snapshot', { responsiveSnapshotCapture: true });
 
-    expect(mockedDriver.executeScript.calls.allArgs()).toEqual(jasmine.arrayContaining([jasmine.arrayContaining(['return window.outerHeight - window.innerHeight + 900'])]));
+    expect(mockedDriver.executeScript).toHaveBeenCalledTimes(4);
     expect(mockedScroll).toHaveBeenCalledWith(mockedDriver, 0.45);
     delete process.env.PERCY_ENABLE_LAZY_LOADING_SCROLL;
     delete process.env.PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT;

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -16,6 +16,7 @@ describe('percySnapshot', () => {
     mockedDriver = {
       getCapabilities: jasmine.createSpy('sendDevToolsCommand').and.returnValue({ getBrowserName: () => 'chrome' }),
       sendDevToolsCommand: jasmine.createSpy('sendDevToolsCommand').and.returnValue(Promise.resolve()),
+      navigate: jasmine.createSpy('navigate').and.returnValue({ refresh: jasmine.createSpy('refresh') }),
       manage: jasmine.createSpy('manage').and.returnValue({
         window: jasmine.createSpy('window').and.returnValue({
           setRect: jasmine.createSpy('setRect').and.returnValue(Promise.resolve()),
@@ -187,6 +188,13 @@ describe('percySnapshot', () => {
     expect(mockedDriver.executeScript).not.toHaveBeenCalledWith('return window.resizeCount');
   });
 
+  it('should reload page if PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE is set', async () => {
+    process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE = true;
+    await percySnapshot(mockedDriver, 'Test Snapshot', { responsiveSnapshotCapture: true });
+    expect(mockedDriver.navigate().refresh).toHaveBeenCalled();
+    delete process.env.PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE;
+  });
+
   it('should wait if RESPONSIVE_CAPTURE_SLEEP_TIME is set', async () => {
     process.env.RESPONSIVE_CAPTURE_SLEEP_TIME = 1;
     spyOn(global, 'setTimeout').and.callThrough();
@@ -199,15 +207,11 @@ describe('percySnapshot', () => {
 
   it('should scroll if PERCY_ENABLE_LAZY_LOADING_SCROLL is set', async () => {
     process.env.PERCY_ENABLE_LAZY_LOADING_SCROLL = true;
-    process.env.PERCY_LAZY_LOAD_SCROLL_TIME = '1.2';
-
     const mockedScroll = spyOn(percySnapshot, 'slowScrollToBottom').and.resolveTo(true);
-
     await percySnapshot(mockedDriver, 'Test Snapshot', { responsiveSnapshotCapture: true });
 
-    expect(mockedScroll).toHaveBeenCalledWith(mockedDriver, 1.2);
+    expect(mockedScroll).toHaveBeenCalledWith(mockedDriver);
     delete process.env.PERCY_ENABLE_LAZY_LOADING_SCROLL;
-    delete process.env.PERCY_LAZY_LOAD_SCROLL_TIME;
   });
 
   it('should use minHeight if PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT is set', async () => {
@@ -221,7 +225,7 @@ describe('percySnapshot', () => {
     await percySnapshot(mockedDriver, 'Test Snapshot', { responsiveSnapshotCapture: true });
 
     expect(mockedDriver.executeScript).toHaveBeenCalledTimes(4);
-    expect(mockedScroll).toHaveBeenCalledWith(mockedDriver, 0.45);
+    expect(mockedScroll).toHaveBeenCalledWith(mockedDriver);
     delete process.env.PERCY_ENABLE_LAZY_LOADING_SCROLL;
     delete process.env.PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT;
   });
@@ -260,8 +264,11 @@ describe('percySnapshot', () => {
 
 describe('#slowScrollToBottom', () => {
   let mockedDriver = { executeScript: jasmine.createSpy('executeScript') };
+  beforeEach(() => {
+    mockedDriver.executeScript.calls.reset();
+  });
 
-  it('should scroll to bottom and sleep as set in env', async () => {
+  it('should scroll to bottom and sleep after loading as set in env', async () => {
     process.env.PERCY_SLEEP_AFTER_LAZY_LOAD_COMPLETE = 2;
     mockedDriver.executeScript.and.returnValues(9, 5, true, 9, true, 9, true);
     spyOn(global, 'setTimeout').and.callThrough();
@@ -271,6 +278,18 @@ describe('#slowScrollToBottom', () => {
     expect(mockedDriver.executeScript).toHaveBeenCalledWith('window.scrollTo(0, 0)');
     expect(mockedDriver.executeScript).toHaveBeenCalledTimes(7);
     delete process.env.PERCY_SLEEP_AFTER_LAZY_LOAD_COMPLETE;
+  });
+
+  it('should scroll to bottom and sleep as set in env', async () => {
+    process.env.PERCY_LAZY_LOAD_SCROLL_TIME = '1.2';
+    mockedDriver.executeScript.and.returnValues(9, 5, true, 9, true, 9, true);
+    spyOn(global, 'setTimeout').and.callThrough();
+
+    await slowScrollToBottom(mockedDriver);
+    expect(setTimeout.calls.allArgs()).toEqual([[jasmine.any(Function), 1200], [jasmine.any(Function), 1200], [jasmine.any(Function), 1000]]);
+    expect(mockedDriver.executeScript).toHaveBeenCalledWith('window.scrollTo(0, 0)');
+    expect(mockedDriver.executeScript).toHaveBeenCalledTimes(7);
+    delete process.env.PERCY_LAZY_LOAD_SCROLL_TIME;
   });
 
   it('should scroll upto 25k px and sleep as passed in function', async () => {


### PR DESCRIPTION
- Expose functionality for slow scrolling for CS
- In responsive snapshot capture support using minHeight as height.

ENV added

- PERCY_RESPONSIVE_CAPTURE_RELOAD_PAGE: Reloads page in responsive snapshot capture after each resize
- PERCY_RESPONSIVE_CAPTURE_MIN_HEIGHT : this will use min height passed in .percy.yml file while resizing browser in responsive capture.
- PERCY_ENABLE_LAZY_LOADING_SCROLL : when this is set we will scroll to bottom after resize in completed and before capturing dom for handling lazy loading.
- PERCY_LAZY_LOAD_SCROLL_TIME : how much time to sleep after each scroll
- PERCY_SLEEP_AFTER_LAZY_LOAD_COMPLETE : time to sleep after getting back to top