### PR TITLE
[PER-6171] Added await for async dom serilization

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,9 +117,9 @@ function ignoreStyleSheetSerializationErrors(options) {
 
 async function captureSerializedDOM(driver, options) {
   /* istanbul ignore next: no instrumenting injected code */
-  let { domSnapshot } = await driver.executeScript(options => ({
+  let { domSnapshot } = await driver.executeScript(async (options) => ({
     /* eslint-disable-next-line no-undef */
-    domSnapshot: PercyDOM.serialize(options)
+    domSnapshot: await PercyDOM.serialize(options)
   }), {
     ...options,
     ignoreCanvasSerializationErrors: ignoreCanvasSerializationErrors(options),


### PR DESCRIPTION
This pull request updates the DOM serialization logic to fully support asynchronous operations and adds comprehensive tests to ensure correct handling of async serialization scenarios. The main change ensures that the `PercyDOM.serialize` function is properly awaited, which allows for more robust and flexible snapshot capturing. The new tests verify correct behavior for async serialization, error handling, option passing, and resource management.

**Async DOM Serialization Improvements:**

* Changed the `captureSerializedDOM` function in `index.js` to properly await the asynchronous `PercyDOM.serialize` call, ensuring that DOM snapshots are captured reliably in async contexts.

**Expanded Test Coverage for Async Serialization:**

* Added a new test suite in `test/index.test.mjs` to verify async DOM serialization, including cases for correct awaiting, handling of options, error handling, responsive snapshot capture, cookie management, passing custom options, and handling complex resources.