### PR TITLE
chore: bump version to 2.2.7-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/selenium-webdriver",
   "description": "Selenium client library for visual testing with Percy",
-  "version": "2.2.7-beta.0",
+  "version": "2.2.7-beta.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-selenium-js",


### PR DESCRIPTION
Version bump to `2.2.7-beta.1` to release the merged CORS-iframe + closed-shadow-DOM work (PER-7292).

Bumps `2.2.7-beta.0` → `2.2.7-beta.1` (next beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)