### PR TITLE
chore: release 2.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "main": "index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/selenium-webdriver",
   "description": "Selenium client library for visual testing with Percy",
-  "version": "2.2.7-beta.2",
+  "version": "2.2.7",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-selenium-js",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `2.2.7-beta.2` to stable `2.2.7`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.

Note: a pre-staged **draft** `v2.2.7` release exists (no git tag yet) — publish/replace it at release time.